### PR TITLE
Remove HTML5shiv

### DIFF
--- a/source/themes/quis/header.php
+++ b/source/themes/quis/header.php
@@ -15,9 +15,6 @@
     <link rel="alternate" type="application/rss+xml" title="quis.cc RSS feed" href="/feed/">
     <meta name="viewport" content="width=device-width, initial-scale=1, minimal-ui">
     <meta name="description" content="<?php echo $pageMeta["description"]?>" />
-    <!--[if lt IE 9]>
-    <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
   </head>
   <body>
     <header>


### PR DESCRIPTION
It’s no longer hosted on the CDN I was using, and I don’t think I need to support IE9 any more.

Fixes #1 